### PR TITLE
ci: Add CI workflow for Python projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+cancel-previous-runs:
+  concurrency_group: ci-${{ github.ref }}
+  concurrency: ${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache-dependencies: true
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          pytest
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+
+      - name: Run linting
+        run: |
+          flake8 .


### PR DESCRIPTION
This PR adds a GitHub Actions CI workflow that runs tests and lints the code on pushes and pull requests to the main branch. It uses matrix builds to test multiple Python versions (3.8, 3.9, 3.10) and includes caching for dependencies to speed up the build process.
---
*Automated by [GitPilot](https://github.com/SoClosee/GitPilot) — your friendly AI maintainer*